### PR TITLE
Feat: add QLearning_L1F1_CKfull_softmax to all sessions

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -138,7 +138,9 @@ def generate_all_jobs() -> list:
             ),
         },
         {  # Apply CompareToThreshold model also to all sessions
-            "data": all_nwbs,
+            "data": get_filtered_nwbs(
+                all_nwbs, df_master.query("session_date >= '2024-09-28'")
+            ),
             "analysis": get_model_fitting_specs(
                 agent_alias_list=[
                     "QLearning_L1F1_CKfull_softmax",  # Bari2019 with CKfull; per discussion 

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -75,7 +75,7 @@ def get_filtered_nwbs(all_nwbs, df_filtered):
     return filtered_nwbs
 
 
-def get_model_fitting_specs(agent_alias_list=None):
+def get_model_fitting_specs(agent_alias_list=None, k_fold_cross_validation=10):
     """Define model fitting specs for specific agents
     
     See https://foraging-behavior-browser.allenneuraldynamics-test.org/RL_model_playground
@@ -98,7 +98,7 @@ def get_model_fitting_specs(agent_alias_list=None):
                 "agent_kwargs": agent_kwargs,
                 "fit_kwargs": {
                     "DE_kwargs": {"polish": True, "seed": 42},
-                    "k_fold_cross_validation": 10,
+                    "k_fold_cross_validation": k_fold_cross_validation,
                 },
             },
         }
@@ -126,8 +126,6 @@ def generate_all_jobs() -> list:
                     "QLearning_L2F1_softmax",  # Hattori2019
                     "WSLS",  # Win-Stay-Lose-Shift
                     "QLearning_L2F1_CKfull_softmax",  # The model with the most parameters
-                    "QLearning_L1F1_CKfull_softmax",  # Bari2019 with CKfull; per discussion 
-                                                      # with Bowen and Xinxin @ 1/7/2026
                 ]
             ),
         },
@@ -137,6 +135,16 @@ def generate_all_jobs() -> list:
                 agent_alias_list=[
                     "ForagingCompareThreshold",  # CompareToThreshold model
                 ]
+            ),
+        },
+        {  # Apply CompareToThreshold model also to all sessions
+            "data": all_nwbs,
+            "analysis": get_model_fitting_specs(
+                agent_alias_list=[
+                    "QLearning_L1F1_CKfull_softmax",  # Bari2019 with CKfull; per discussion 
+                                                      # with Bowen and Xinxin @ 1/7/2026
+                ],
+                k_fold_cross_validation=None  # Skip within-session CV as it's problematic
             ),
         },
     ]

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -126,6 +126,8 @@ def generate_all_jobs() -> list:
                     "QLearning_L2F1_softmax",  # Hattori2019
                     "WSLS",  # Win-Stay-Lose-Shift
                     "QLearning_L2F1_CKfull_softmax",  # The model with the most parameters
+                    "Qlearning_L1F1_CKfull_softmax",  # Bari2019 with CKfull; per discussion 
+                                                      # with Bowen and Xinxin @ 1/7/2026
                 ]
             ),
         },

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -126,7 +126,7 @@ def generate_all_jobs() -> list:
                     "QLearning_L2F1_softmax",  # Hattori2019
                     "WSLS",  # Win-Stay-Lose-Shift
                     "QLearning_L2F1_CKfull_softmax",  # The model with the most parameters
-                    "Qlearning_L1F1_CKfull_softmax",  # Bari2019 with CKfull; per discussion 
+                    "QLearning_L1F1_CKfull_softmax",  # Bari2019 with CKfull; per discussion 
                                                       # with Bowen and Xinxin @ 1/7/2026
                 ]
             ),


### PR DESCRIPTION
Adding Bari_with_CKfull per [discussion](https://www.notion.so/hanhou/Neuropixels-DFT-Focus-Group-1dd3ef97e735802595b8fc5740e7aa40?source=copy_link#2e13ef97e7358019927deba3a4a611de) with Bowen and Xinxin.

Sessions before 2024-09-28 have been fitted with this model (cross_validation=10). Only going to fit session > 2024-09-28 and with cross_validation = None (since within-session cross-validation is problematic)